### PR TITLE
Fix nonbreaking typo in Test 14

### DIFF
--- a/ecom_proj/tests/test_14_item_remove.py
+++ b/ecom_proj/tests/test_14_item_remove.py
@@ -61,10 +61,10 @@ in order to pass the test. Pay attention to order and formatting of your data.
 """
 
 
-class Test_increase_cart_item(APITestCase):
+class Test_item_remove(APITestCase):
     fixtures = ["items.json"]
 
-    def test_011_increase_cart_item(self):
+    def test_14_item_remove(self):
         client = Client()
         sign_up_response = client.post(
             reverse("signup"),


### PR DESCRIPTION
**Do not merge while Whiskey Django assessment attempt 1 is in progress**

Test 14's test class and the method inside that class are named wrong - they have the same name as Test 11. This doesnt break anything but is confusing to students when they read the tests and we got feedback on it.

Renamed to correct name.